### PR TITLE
more installer fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -220,8 +220,8 @@ apt autoremove --yes
 log "Activating virtualenv"
 source \${PROJECT_ENV}/bin/activate
 
-log "Pulling changes from \${PROJECT_REMOTE}/\${PROJECT_BRANCH}"
-git pull \${PROJECT_REMOTE}/\${PROJECT_BRANCH}
+log "Pulling changes from \${PROJECT_REMOTE} \${PROJECT_BRANCH}"
+git pull \${PROJECT_REMOTE} \${PROJECT_BRANCH}
 
 log "Syncing pip requirements"
 pip install -r \${PROJECT_DIR}/requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,9 @@
 # This script installs cbox-bot, its requirements, system updates, a systemd
 # service unit, a user to run it all, and these admin scripts:
 #
-#   /usr/local/sbin/upgrade.sh  - upgrades the system and git repo
-#   /usr/local/sbin/status.sh   - shows you systemctl status cbox-bot
-#   /usr/local/sbin/snoop.sh    - shows you journalctl -fu cbox-bot
+#   /usr/local/bin/upgrade.sh  - upgrades the system and git repo
+#   /usr/local/bin/status.sh   - shows you systemctl status cbox-bot
+#   /usr/local/bin/snoop.sh    - shows you journalctl -fu cbox-bot
 
 # The installer targets Debian 9 Stretch running in a Proxmox LXC container.
 # Don't forget to set up config.py and import the data archive from cbox.
@@ -76,10 +76,10 @@ PROJECT_REPO=https://github.com/Golen87/cbox-bot.git
 PROJECT_USER=chu
 
 # Scripts
-UPGRADE_SCRIPT=/usr/local/sbin/upgrade.sh
+UPGRADE_SCRIPT=/usr/local/bin/upgrade.sh
 UPGRADE_LOG_COLOR=3
-STATUS_SCRIPT=/usr/local/sbin/status.sh
-SNOOP_SCRIPT=/usr/local/sbin/snoop.sh
+STATUS_SCRIPT=/usr/local/bin/status.sh
+SNOOP_SCRIPT=/usr/local/bin/snoop.sh
 
 # Logging
 LOG_PREFIX="[install.sh]"

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ DEB_BASE_TARGET=stretch
 DEB_COMPONENTS="main contrib non-free"
 DEB_MIRROR=http://ftp.us.debian.org/debian
 DEB_PKG_EXTRA="cron-apt curl htop sudo tree vim wget"
-DEB_PKG_REQUIRED="git python2-dev virtualenv"
+DEB_PKG_REQUIRED="git python2.7-dev virtualenv"
 
 # Project
 PROJECT_BRANCH=master

--- a/install.sh
+++ b/install.sh
@@ -163,7 +163,7 @@ Description=cbox-bot
 [Service]
 User=${PROJECT_USER}
 WorkingDirectory=${PROJECT_DIR}
-ExecStart=${PROJECT_ENV}/bin/python src/bot.py
+ExecStart=${PROJECT_ENV}/bin/python -u src/bot.py
 
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,9 @@
 # This script installs cbox-bot, its requirements, system updates, a systemd
 # service unit, a user to run it all, and these admin scripts:
 #
-#   /usr/local/sbin/upgrade.sh
-#   /usr/local/sbin/status.sh
+#   /usr/local/sbin/upgrade.sh  - upgrades the system and git repo
+#   /usr/local/sbin/status.sh   - shows you systemctl status cbox-bot
+#   /usr/local/sbin/snoop.sh    - shows you journalctl -fu cbox-bot
 
 # The installer targets Debian 9 Stretch running in a Proxmox LXC container.
 # Don't forget to set up config.py and import the data archive from cbox.
@@ -78,7 +79,7 @@ PROJECT_USER=chu
 UPGRADE_SCRIPT=/usr/local/sbin/upgrade.sh
 UPGRADE_LOG_COLOR=3
 STATUS_SCRIPT=/usr/local/sbin/status.sh
-STATUS_LOG_COLOR=6
+SNOOP_SCRIPT=/usr/local/sbin/snoop.sh
 
 # Logging
 LOG_PREFIX="[install.sh]"
@@ -181,9 +182,16 @@ systemctl enable cbox-bot.service
 log "Installing $(basename ${STATUS_SCRIPT})"
 cat <<EOF > ${STATUS_SCRIPT}
 #!/bin/bash
-systemctl --no-pager status cbox-bot.service
+systemctl --no-pager -l status cbox-bot.service
 EOF
 chmod 700 ${STATUS_SCRIPT}
+
+log "Installing $(basename ${SNOOP_SCRIPT})"
+cat <<EOF > ${SNOOP_SCRIPT}
+#!/bin/bash
+journalctl -fu cbox-bot.service
+EOF
+chmod 700 ${SNOOP_SCRIPT}
 
 log "Installing $(basename ${UPGRADE_SCRIPT})"
 cat <<EOF > ${UPGRADE_SCRIPT}


### PR DESCRIPTION
- fixes python stdout not going to journalctl by running with the `-u` unbuffered flag.
- fixes apt package name
- adds snoop.sh for showing journalctl output easily.